### PR TITLE
feat: 헤더에 GitHub 저장소 링크 아이콘 추가

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -13,12 +13,32 @@ export default function Layout({ children, onAddClick }: LayoutProps) {
           <h1 className="text-xl font-bold tracking-tight text-gray-900">
             Checkin
           </h1>
-          <button
-            onClick={onAddClick}
-            className="rounded-lg bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-700"
-          >
-            + 글 추가
-          </button>
+          <div className="flex items-center gap-3">
+            <a
+              href="https://github.com/Jiwook00/checkin"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-gray-500 transition-colors hover:text-gray-900"
+              aria-label="GitHub 저장소"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="22"
+                height="22"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z" />
+              </svg>
+            </a>
+            <button
+              onClick={onAddClick}
+              className="rounded-lg bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-700"
+            >
+              + 글 추가
+            </button>
+          </div>
         </div>
       </header>
       <main className="mx-auto max-w-5xl px-6 py-8">{children}</main>


### PR DESCRIPTION
메인 화면 헤더 우측에 GitHub 아이콘 링크를 추가했습니다.
'+ 글 추가' 버튼 왼쪽에 위치하며, 클릭 시 새 탭으로 저장소가 열립니다.

https://claude.ai/code/session_015gjMo4b1neh5QU9SiBcf6L