### PR TITLE
feat: Google OAuth 로그인 및 멤버 접근 제어 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,8 +6,11 @@ import SessionFilter from "./components/SessionFilter";
 import ArticleList from "./components/ArticleList";
 import ArticleReader from "./components/ArticleReader";
 import AddArticleModal from "./components/AddArticleModal";
+import LoginPage from "./components/LoginPage";
+import { useAuth } from "./hooks/useAuth";
 
 export default function App() {
+  const { authState, signInWithGoogle, signOut } = useAuth();
   const [articles, setArticles] = useState<Retrospective[]>([]);
   const [loading, setLoading] = useState(true);
   const [selectedArticle, setSelectedArticle] = useState<Retrospective | null>(
@@ -72,6 +75,18 @@ export default function App() {
     await fetchArticles();
   };
 
+  if (authState.status === "loading") {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-gray-50">
+        <p className="text-sm text-gray-400">로딩 중...</p>
+      </div>
+    );
+  }
+
+  if (authState.status === "unauthenticated") {
+    return <LoginPage onLogin={signInWithGoogle} error={authState.error} />;
+  }
+
   // 리더 뷰가 열려 있으면 리더만 표시
   if (selectedArticle) {
     return (
@@ -83,7 +98,11 @@ export default function App() {
   }
 
   return (
-    <Layout onAddClick={() => setShowAddModal(true)}>
+    <Layout
+      onAddClick={() => setShowAddModal(true)}
+      nickname={authState.member.nickname}
+      onLogout={signOut}
+    >
       <div className="mb-6">
         <SessionFilter
           sessions={sessions}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -3,9 +3,16 @@ import { type ReactNode } from "react";
 interface LayoutProps {
   children: ReactNode;
   onAddClick: () => void;
+  nickname: string;
+  onLogout: () => void;
 }
 
-export default function Layout({ children, onAddClick }: LayoutProps) {
+export default function Layout({
+  children,
+  onAddClick,
+  nickname,
+  onLogout,
+}: LayoutProps) {
   return (
     <div className="min-h-screen bg-gray-50">
       <header className="sticky top-0 z-10 border-b border-gray-200 bg-white/80 backdrop-blur-sm">
@@ -37,6 +44,13 @@ export default function Layout({ children, onAddClick }: LayoutProps) {
               className="rounded-lg bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-700"
             >
               + 글 추가
+            </button>
+            <span className="text-sm text-gray-500">{nickname}</span>
+            <button
+              onClick={onLogout}
+              className="text-sm text-gray-400 transition-colors hover:text-gray-700"
+            >
+              로그아웃
             </button>
           </div>
         </div>

--- a/src/components/LoginPage.tsx
+++ b/src/components/LoginPage.tsx
@@ -1,0 +1,56 @@
+interface LoginPageProps {
+  onLogin: () => void;
+  error?: string;
+}
+
+export default function LoginPage({ onLogin, error }: LoginPageProps) {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50">
+      <div className="w-full max-w-sm rounded-2xl bg-white p-10 shadow-sm">
+        <div className="mb-8 text-center">
+          <h1 className="mb-2 text-2xl font-bold tracking-tight text-gray-900">
+            Checkin
+          </h1>
+          <p className="text-sm text-gray-500">회고 멤버 전용 서비스입니다</p>
+        </div>
+
+        {error && (
+          <div className="mb-6 rounded-lg bg-red-50 px-4 py-3 text-sm text-red-600">
+            {error}
+          </div>
+        )}
+
+        <button
+          onClick={onLogin}
+          className="flex w-full items-center justify-center gap-3 rounded-lg border border-gray-200 bg-white px-4 py-3 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            width="18"
+            height="18"
+            aria-hidden="true"
+          >
+            <path
+              fill="#4285F4"
+              d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+            />
+            <path
+              fill="#34A853"
+              d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+            />
+            <path
+              fill="#FBBC05"
+              d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z"
+            />
+            <path
+              fill="#EA4335"
+              d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+            />
+          </svg>
+          Google로 로그인
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,103 @@
+import { useEffect, useState } from "react";
+import { supabase } from "../lib/supabase";
+
+interface Member {
+  id: string;
+  email: string;
+  nickname: string;
+}
+
+type AuthState =
+  | { status: "loading" }
+  | { status: "unauthenticated"; error?: string }
+  | { status: "authenticated"; member: Member };
+
+export function useAuth() {
+  const [authState, setAuthState] = useState<AuthState>({ status: "loading" });
+
+  const signInWithGoogle = async () => {
+    await supabase.auth.signInWithOAuth({
+      provider: "google",
+      options: { redirectTo: window.location.origin },
+    });
+  };
+
+  const signOut = async () => {
+    await supabase.auth.signOut();
+  };
+
+  // Google OAuth 콜백 후 이메일 검증 및 checkin_members upsert
+  const validateAndUpsertMember = async (userId: string, email: string) => {
+    // 화이트리스트 확인
+    const { data: allowed } = await supabase
+      .from("checkin_allowed_members")
+      .select("nickname")
+      .eq("email", email)
+      .maybeSingle();
+
+    if (!allowed) {
+      await supabase.auth.signOut();
+      setAuthState({
+        status: "unauthenticated",
+        error: "접근 권한이 없는 계정입니다.",
+      });
+      return;
+    }
+
+    // checkin_members upsert
+    const { error } = await supabase
+      .from("checkin_members")
+      .upsert(
+        { id: userId, email, nickname: allowed.nickname },
+        { onConflict: "id" },
+      );
+
+    if (error) {
+      await supabase.auth.signOut();
+      setAuthState({
+        status: "unauthenticated",
+        error: "로그인 처리 중 오류가 발생했습니다.",
+      });
+      return;
+    }
+
+    setAuthState({
+      status: "authenticated",
+      member: { id: userId, email, nickname: allowed.nickname },
+    });
+  };
+
+  useEffect(() => {
+    // 현재 세션 확인
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (!session?.user) {
+        setAuthState({ status: "unauthenticated" });
+        return;
+      }
+      const { id, email } = session.user;
+      validateAndUpsertMember(id, email ?? "");
+    });
+
+    // 세션 변경 감지 (OAuth 콜백 포함)
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (!session?.user) {
+        setAuthState((prev) =>
+          prev.status === "loading"
+            ? { status: "unauthenticated" }
+            : prev.status === "authenticated"
+              ? { status: "unauthenticated" }
+              : prev,
+        );
+        return;
+      }
+      const { id, email } = session.user;
+      validateAndUpsertMember(id, email ?? "");
+    });
+
+    return () => subscription.unsubscribe();
+  }, []);
+
+  return { authState, signInWithGoogle, signOut };
+}

--- a/supabase/migrations/20260227000000_create_allowed_members.sql
+++ b/supabase/migrations/20260227000000_create_allowed_members.sql
@@ -1,0 +1,45 @@
+-- 허용 멤버 화이트리스트
+CREATE TABLE checkin_allowed_members (
+  email    TEXT PRIMARY KEY,
+  nickname TEXT NOT NULL
+);
+
+INSERT INTO checkin_allowed_members (email, nickname) VALUES
+  ('iris3455@gmail.com',    'iris'),
+  ('siamore9724@gmail.com', 'rony'),
+  ('jwkim775@gmail.com',    'danny');
+
+ALTER TABLE checkin_allowed_members ENABLE ROW LEVEL SECURITY;
+
+-- 인증된 사용자는 화이트리스트 전체 조회 가능 (이메일 검증에 사용)
+CREATE POLICY "Allow authenticated select" ON checkin_allowed_members
+  FOR SELECT
+  TO authenticated
+  USING (true);
+
+-- 앱 유저 프로필 (auth.users 와 1:1 대응)
+CREATE TABLE checkin_members (
+  id         UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  email      TEXT NOT NULL UNIQUE,
+  nickname   TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+ALTER TABLE checkin_members ENABLE ROW LEVEL SECURITY;
+
+-- 본인 row만 조회 가능
+CREATE POLICY "Allow own select" ON checkin_members
+  FOR SELECT
+  TO authenticated
+  USING (auth.uid() = id);
+
+-- 본인 row만 삽입/갱신 가능
+CREATE POLICY "Allow own upsert" ON checkin_members
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (auth.uid() = id);
+
+CREATE POLICY "Allow own update" ON checkin_members
+  FOR UPDATE
+  TO authenticated
+  USING (auth.uid() = id);


### PR DESCRIPTION
## What is this PR?

Google OAuth를 통한 로그인 기능과 화이트리스트 기반 멤버 접근 제어를 구현합니다. 허용된 이메일만 서비스에 입장할 수 있으며, 비인가 계정은 즉시 로그아웃 처리됩니다.

## Changes

- **DB 마이그레이션** (`supabase/migrations/`)
  - `checkin_allowed_members` 테이블 생성 — 허용 이메일/닉네임 화이트리스트 (3명 시드 데이터 포함)
  - `checkin_members` 테이블 생성 — 앱 유저 프로필, `auth.users`와 1:1 연동 (RLS 적용)

- **신규 파일**
  - `src/hooks/useAuth.ts` — Google OAuth 로그인, 이메일 화이트리스트 검증, `checkin_members` upsert 처리
  - `src/components/LoginPage.tsx` — Google 로그인 버튼 UI, 미허가 계정 에러 메시지 표시

- **기존 파일 수정**
  - `src/App.tsx` — auth guard 추가 (loading → unauthenticated → authenticated 3단계 분기)
  - `src/components/Layout.tsx` — 헤더에 현재 유저 닉네임 표시 및 로그아웃 버튼 추가

Closes #8