### PR TITLE
feat: retrospectives RLS 정책을 인증 멤버 전용으로 교체

### DIFF
--- a/supabase/migrations/20260227000001_rls_retrospectives_authenticated.sql
+++ b/supabase/migrations/20260227000001_rls_retrospectives_authenticated.sql
@@ -1,0 +1,7 @@
+-- retrospectives RLS: 인증된 멤버만 읽기 허용
+DROP POLICY IF EXISTS "Allow all access" ON retrospectives;
+
+CREATE POLICY "Allow authenticated read" ON retrospectives
+  FOR SELECT
+  TO authenticated
+  USING (true);


### PR DESCRIPTION
## 변경 사항

`retrospectives` 테이블의 RLS 정책이 `USING (true)`로 설정되어 미인증 사용자도 DB에 직접 접근할 수 있는 문제를 수정합니다.

- 기존 `"Allow all access"` 정책 제거
- `authenticated` 유저만 SELECT 가능하도록 정책 교체

## 관련 항목

Closes #9

---

<details>
<summary>AI 협업 로그 (선택)</summary>

**사용 도구**: Claude Code

**작업 요약**: 기존 `USING (true)` RLS 정책의 보안 문제를 파악하고, 인증 멤버 전용 SELECT 정책으로 교체하는 마이그레이션을 작성했다.

**핵심 프롬프트**:

> "1번 작업은 구현되어 있지 않나?. 그리고 2번 Supabase RLS 정책 설정이라는 게 내가 생성한 회고는 내가 수정할 수 있게 하는 그런 걸 말하는 거지?"

> "일단 읽기 작업은 우리 멤버들이라면 모두 어떤 게시글이든 읽을 수 있어야 해."

**주요 결정**:

- 1번 작업(비인증 사용자 리다이렉트)은 이미 `App.tsx`에 구현되어 있어 생략.
- 글 소유자 기반 수정/삭제(user_id 컬럼 추가)는 별도 이슈(#17)로 분리 — 스키마 변경 + UI 작업이 포함돼 범위가 커서.
- `user_id` 대신 `member_id`로 컬럼명 결정 — 앱이 `checkin_members`를 유저 테이블로 사용하므로 더 자연스러운 참조.

</details>